### PR TITLE
support bzlmod

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Ira Strawser
+# SPDX-License-Identifier: MIT
+
+module(
+    name = "ewdk_cc_toolchain",
+    version = "1.0.11",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "rules_cc", version = "0.0.9")
+bazel_dep(name = "platforms", version = "0.0.10")
+
+toolchains = use_extension("//:ewdk_extension.bzl", "toolchains")
+use_repo(toolchains, "ewdk_toolchains")
+register_toolchains("@ewdk_toolchains//:all")

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ load("@bazel_ewdk_cc//:ewdk_cc_configure.bzl", "register_ewdk_cc_toolchains")
 register_ewdk_cc_toolchains()
 ```
 
+Or, using the bzlmod system update your MODULE.bazel file with the following. The project is not yet
+published to the bzlmod repository, so you will need to use git_override and specify the a commit:
+```starlark
+bazel_dep(name = "ewdk_cc_toolchain")
+git_override(
+    module_name = "ewdk_cc_toolchain",
+    remote = "https://github.com/0xf005ba11/bazel_ewdk_cc.git",
+    commit = "INSERT_COMMIT_HERE",
+)
+```
+
 Add the following to your .bazelrc (this should hopefully no longer be needed once this [issue](https://github.com/bazelbuild/bazel/issues/7260) is closed in bazel 7.0.0):
 ```
 build --incompatible_enable_cc_toolchain_resolution

--- a/ewdk_extension.bzl
+++ b/ewdk_extension.bzl
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Ira Strawser
+# SPDX-License-Identifier: MIT
+
+load("//:ewdk_cc_configure.bzl", "ewdk_cc_autoconf_toolchains")
+
+toolchains = module_extension(
+    implementation = lambda ctx: ewdk_cc_autoconf_toolchains(name = "ewdk_toolchains")
+)


### PR DESCRIPTION
This PR supports pulling in the EWDK toolchains via the bzlmod system.