### PR TITLE
Drop local=True, declare environ on ewdk_cc_autoconf_toolchains

### DIFF
--- a/ewdk_cc_configure.bzl
+++ b/ewdk_cc_configure.bzl
@@ -2735,8 +2735,12 @@ def _ewdk_cc_autoconf_toolchains_impl(repository_ctx):
 
 ewdk_cc_autoconf_toolchains = repository_rule(
     implementation = _ewdk_cc_autoconf_toolchains_impl,
-    local = True,
     configure = True,
+    environ = [
+        "EWDKDIR",
+        "PROCESSOR_ARCHITECTURE",
+        "PROCESSOR_IDENTIFIER",
+    ],
 )
 
 def register_ewdk_cc_toolchains(name = "ewdk_cc"):


### PR DESCRIPTION
Re-probing the EWDK on every server restart was wasteful. Declaring environ lets Bazel re-run the rule only when EWDKDIR or the arch vars change, while still regenerating toolchains without a clean --expunge.