### PR TITLE
Make ewdk_toolchain default constraint opt-in via module extension

### DIFF
--- a/BUILD.ewdk.toolchains.tpl
+++ b/BUILD.ewdk.toolchains.tpl
@@ -14,7 +14,7 @@ load(":ewdk_command.bzl", "ewdk_command_config")
 
 constraint_setting(
     name = "ewdk_toolchain",
-    default_constraint_value = ":ewdk_cc",
+    %{ewdk_default_constraint}
     visibility = ["//visibility:public"],
 )
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,23 @@ use_repo(ewdk_toolchains, ewdk_cc = "ewdk_toolchains")
 register_toolchains("@ewdk_cc//:all")
 ```
 
+### Disabling the default toolchain constraint
+
+By default, the `ewdk_toolchain` constraint setting sets its `default_constraint_value` to
+`ewdk_cc`, so every Windows platform resolves to the EWDK toolchain whenever `EWDKDIR` is set.
+If you only want the EWDK toolchain selected on platforms that explicitly carry the `ewdk_cc`
+constraint value (e.g. to keep normal user-mode builds on a different C++ toolchain), opt out via
+the extension's `configure` tag:
+
+```starlark
+ewdk_toolchains = use_extension("@ewdk_cc_toolchains//:ewdk_extension.bzl", "toolchains")
+ewdk_toolchains.configure(default_constraint = False)
+use_repo(ewdk_toolchains, ewdk_cc = "ewdk_toolchains")
+```
+
+When disabled, add `@ewdk_cc//:ewdk_cc` to the `constraint_values` of the platforms that should
+use the EWDK toolchain.
+
 Add the following to your .bazelrc (this should hopefully no longer be needed once this [issue](https://github.com/bazelbuild/bazel/issues/7260) is closed in bazel 7.0.0):
 ```
 build --incompatible_enable_cc_toolchain_resolution

--- a/ewdk_cc_configure.bzl
+++ b/ewdk_cc_configure.bzl
@@ -2638,7 +2638,18 @@ def _configure_ewdk_cc(repository_ctx, host_cpu):
     arms = ["arm", "arm64"]
     plat32 = ["x86", "arm"]
     platforms = intels + arms
+
+    # When opted in (default), the ewdk_toolchain constraint_setting defaults
+    # every platform to :ewdk_cc. Consumers can disable this via the module
+    # extension's configure tag (default_constraint = False) so that normal
+    # user-mode builds aren't silently routed through the driver toolchain.
+    if repository_ctx.attr.default_constraint:
+        default_constraint = 'default_constraint_value = ":ewdk_cc",'
+    else:
+        default_constraint = "# default_constraint_value omitted (configure(default_constraint = False))"
+
     tpl_vars = {
+        "%{ewdk_default_constraint}": default_constraint,
         "%{ewdk_launch_env}": env_str.replace("\\", "\\\\"),
         "%{msvc_env_tmp}": env["TMP"].replace("\\", "\\\\"),
         "%{msvc_rc_path}": env["_RC_PATH"].replace("\\", "/"),
@@ -2737,6 +2748,12 @@ ewdk_cc_autoconf_toolchains = repository_rule(
     implementation = _ewdk_cc_autoconf_toolchains_impl,
     local = True,
     configure = True,
+    attrs = {
+        "default_constraint": attr.bool(
+            default = True,
+            doc = "If True, the ewdk_toolchain constraint_setting defaults to :ewdk_cc.",
+        ),
+    },
 )
 
 def register_ewdk_cc_toolchains(name = "ewdk_cc"):

--- a/ewdk_extension.bzl
+++ b/ewdk_extension.bzl
@@ -3,6 +3,29 @@
 
 load("//:ewdk_cc_configure.bzl", "ewdk_cc_autoconf_toolchains")
 
+def _toolchains_impl(ctx):
+    # Default to upstream behavior: ewdk_toolchain defaults to :ewdk_cc. A module
+    # can opt out with toolchains.configure(default_constraint = False). Last
+    # configure tag wins; typically only the root module configures this.
+    default_constraint = True
+    for mod in ctx.modules:
+        for tag in mod.tags.configure:
+            default_constraint = tag.default_constraint
+
+    ewdk_cc_autoconf_toolchains(
+        name = "ewdk_toolchains",
+        default_constraint = default_constraint,
+    )
+
 toolchains = module_extension(
-    implementation = lambda ctx: ewdk_cc_autoconf_toolchains(name = "ewdk_toolchains")
+    implementation = _toolchains_impl,
+    tag_classes = {
+        "configure": tag_class(attrs = {
+            "default_constraint": attr.bool(
+                default = True,
+                doc = "If True (default), the ewdk_toolchain constraint_setting " +
+                      "defaults every platform to :ewdk_cc.",
+            ),
+        }),
+    },
 )


### PR DESCRIPTION
The ewdk_toolchain constraint_setting hardcoded default_constraint_value = :ewdk_cc, routing every Windows platform through the driver toolchain whenever EWDK was configured. Expose this as a configure tag on the toolchains module extension (default_constraint, default True) so consumers can disable it without patching the template. Default stays True to preserve existing behavior.